### PR TITLE
Fix Proton template bundle directory structure

### DIFF
--- a/doc_source/svc-bundle-create.md
+++ b/doc_source/svc-bundle-create.md
@@ -14,7 +14,7 @@
 To create a service template bundle, you must create the schema, CloudFormation and manifest files as shown in the following example directories\.
 
 ```
-/schema
+ /schema
    schema.yaml
  /infrastructure
    manifest.yaml


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Working with AWS Proton for a few days, it seems like the directory structure should be flat with `/schema` `/infrastructure` and `/pipeline` all living inside the same directory level.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
